### PR TITLE
Adjust the HTTP to HTTPs issue. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ustyc
 Title: Fetch US Treasury yield curve data.
-Version: 1.0.001
+Version: 1.0.1
 Date: 2020-05-27
-Author: Matt Barry <mrb@softisms.com>, edit J.Fluharty <jonathan.fluharty@mail.wvu.edu>
+Author: Matt Barry <mrb@softisms.com>
 Maintainer: Matt Barry <mrb@softisms.com>
 Description: Forms a query to submit for US Treasury yield curve data, posting
     this query to the US Treasury web site's data feed service.  By default the

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ustyc
 Title: Fetch US Treasury yield curve data.
-Version: 1.0.0
-Date: 2014-06-12
-Author: Matt Barry <mrb@softisms.com>
+Version: 1.0.001
+Date: 2020-05-27
+Author: Matt Barry <mrb@softisms.com>, edit J.Fluharty <jonathan.fluharty@mail.wvu.edu>
 Maintainer: Matt Barry <mrb@softisms.com>
 Description: Forms a query to submit for US Treasury yield curve data, posting
     this query to the US Treasury web site's data feed service.  By default the

--- a/R/yieldcurve.R
+++ b/R/yieldcurve.R
@@ -40,7 +40,9 @@ getYieldCurve <- function(year=NULL,
       parameters = paste("?$filter=",mloc,sep='')
   }
   
-  doc <- xmlParse(paste(location,parameters,sep=''))
+  require(curl)
+    req <- curl_fetch_memory(paste(location, parameters, sep = ""))
+    doc <- xmlParse(rawToChar(req$content))
   if (is.null(doc)) {
     warning(paste("Could not parse the location",location))
     return(NULL)


### PR DESCRIPTION
Made an adjustment so the redirect from http to https is handled automatically as suggested by Andre in your discussion area. 

One reason I prefer to edit the master rather than use the fix as suggested by Andre is that in compiling a markdown file the markdown is rendered in its own environment. It is fast to render it with the appropriately installed packages rather than loading a saved environment with the 'fixed' method. Also stops from fixing it each time you load R. 

Nice package by the way! 